### PR TITLE
feat: add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to npm
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,83 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate + npm publish --dry-run only (no publish/tag/release)"
+        type: boolean
+        default: false
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Read package name + version
+        id: pkg
+        run: |
+          echo "name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Version gate (skip if already on npm)
+        id: gate
+        run: |
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} already published — skipping."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: npm publish (dry run)
+        if: steps.gate.outputs.publish == 'true' && inputs.dry_run == true
+        run: npm publish --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: npm publish
+        if: steps.gate.outputs.publish == 'true' && inputs.dry_run != true
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag + GitHub Release
+        if: steps.gate.outputs.publish == 'true' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.pkg.outputs.version }}
+        run: |
+          TAG="v$VERSION"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::$TAG already exists — skipping release."; exit 0
+          fi
+          NOTES="$(mktemp)"
+          awk -v v="$VERSION" '
+            BEGIN { gsub(/\./, "\\.", v) }   # escape dots so 1.6.8 is literal, not "any char"
+            $0 ~ "^## \\[" v "\\]" {grab=1; next}
+            grab && /^## \[/ {exit}
+            grab {print}
+          ' CHANGELOG.md > "$NOTES"
+          if [ -s "$NOTES" ]; then
+            gh release create "$TAG" --title "$TAG" --notes-file "$NOTES" --target "$GITHUB_SHA"
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes --target "$GITHUB_SHA"
+          fi


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml`, mirroring `bitpool/edge-bacnet`'s workflow byte-for-byte. Triggers on push to `master` + manual `workflow_dispatch`; reads name/version from `package.json`, skips if that version is already published to npm, otherwise runs `npm publish --provenance --access public` (dry-run supported via input), then tags the commit and creates a GitHub release (using `CHANGELOG.md` notes if present, else `--generate-notes`).

Part of rolling this workflow out to the other public `@bitpoolos/...` packages.

## Before this can actually run

This repo still needs, out of scope for this PR:
- A `release` GitHub Environment configured
- An `NPM_TOKEN` secret set on that environment

Without those, pushes to `master` will fail at the publish step until provisioning is done separately.